### PR TITLE
Update usage-guide.md

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -195,7 +195,7 @@ collection = client.get_collection(name="my_collection", embedding_function=emb_
 If you later wish to `get_collection`, you MUST do so with the embedding function you supplied while creating the collection
 :::
 
-The embedding function takes text as input, and performs tokenization and embedding. If no embedding function is supplied, Chroma will use [sentence transfomer](https://www.sbert.net/index.html) as a default.
+The embedding function takes text as input, and performs tokenization and embedding. If no embedding function is supplied, Chroma will use [sentence transformer](https://www.sbert.net/index.html) as a default.
 
 </TabItem>
 <TabItem value="js" label="JavaScript">


### PR DESCRIPTION
Spelling typo. Modified "sentence transfomer" to "sentence transformer"